### PR TITLE
feat: add daily-tech-brief skill

### DIFF
--- a/daily-tech-brief/SKILL.md
+++ b/daily-tech-brief/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: daily-tech-brief
+description: 'Fetches and summarizes the top 10 tech news stories of the day, curated for software developers. Use when asked for a "daily tech brief", "tech news", "what happened in tech today", "top tech stories", "morning tech roundup", or any request for current technology headlines, developer news, or software industry updates. Covers AI/ML, security, open source, cloud, programming languages, developer tools, and industry news from sources like Hacker News, The Verge, Ars Technica, Wired, Engadget, MIT Technology Review, TechCrunch, and more. Outputs an HTML page opened in the browser.'
+---
+
+# Daily Tech Brief
+
+Fetches the top 10 technology news stories of the day from across the web, curated specifically for software developers, and presents them as a clean, readable HTML page opened directly in the user's browser.
+
+## When to Use This Skill
+
+- User says "daily tech brief", "tech brief", or "morning roundup"
+- User asks "what happened in tech today?" or "what's the top tech news?"
+- User wants a developer-focused news digest
+- User asks for top stories from Hacker News, The Verge, Ars Technica, Wired, etc.
+- User wants tech news as an HTML page or in the browser
+
+## Sources to Fetch From
+
+Pull from as many of these as possible in parallel to get broad coverage:
+
+| Source | URL | Best For |
+|--------|-----|----------|
+| Hacker News | https://news.ycombinator.com/ | Developer community picks, open source, security |
+| The Verge | https://www.theverge.com/tech | Consumer tech, industry news, product launches |
+| Ars Technica | https://feeds.arstechnica.com/arstechnica/index (RSS) | Deep technical coverage, science, policy |
+| Wired | https://www.wired.com/ | Security, culture, policy, in-depth features |
+| Engadget | https://www.engadget.com/ | Consumer tech, hardware, streaming, AI products |
+| MIT Technology Review | https://www.technologyreview.com/ | Research, emerging tech, energy, AI |
+| TechCrunch | https://techcrunch.com/ | Startups, funding, industry moves |
+| 9to5Mac / MacRumors | https://9to5mac.com / https://www.macrumors.com | Apple platform news |
+| The Register | https://www.theregister.com/ | Enterprise tech, security, British wit |
+| Krebs on Security | https://krebsonsecurity.com/ | Security and cybercrime |
+
+## Step-by-Step Workflow
+
+### Step 1: Fetch Headlines in Parallel
+
+Use the `web_fetch` tool to load **all sources simultaneously** in a single response. Fetch at least 6–8 sources at once. Use RSS feeds where available (e.g., Ars Technica) since they return clean structured content.
+
+### Step 2: Fetch Article Detail for Top Candidates
+
+From the headlines gathered, identify ~15 strong candidates. For the most promising stories, fetch the article page to get enough detail to write a 2-paragraph summary. Prioritize:
+
+- **Developer relevance**: tools, languages, frameworks, APIs, open source
+- **Security**: vulnerabilities, supply chain attacks, surveillance policy
+- **AI/ML**: model releases, research, product launches, policy
+- **Industry**: layoffs, acquisitions, regulatory actions, major product changes
+- **Freshness**: prefer stories from the current day or previous 24 hours
+
+Avoid:
+- Deals/sales roundups unless the product is developer-relevant
+- Celebrity or non-tech news
+- Opinion pieces without a newsworthy hook
+
+### Step 3: Select the Top 10
+
+Choose 10 stories that collectively span multiple categories. Aim for variety:
+- At least 2 AI/ML stories
+- At least 1 security or privacy story
+- At least 1 developer tools / open source story
+- Remaining from industry, hardware, policy, or research
+
+### Step 4: Write Summaries
+
+For each story write **2 short paragraphs** (~3–5 sentences each):
+- **Paragraph 1**: What happened and why it matters
+- **Paragraph 2**: Context, implications, or developer-relevant detail
+
+### Step 5: Generate and Open HTML
+
+Create the HTML file at `/tmp/daily-tech-brief-YYYY-MM-DD.html` using the template in `references/html-template.md`. Then open it with:
+
+```bash
+open /tmp/daily-tech-brief-YYYY-MM-DD.html
+```
+
+## Output Requirements
+
+- Barebones, readable HTML — minimal CSS, no heavy frameworks
+- Each story must include: headline, source name, direct article link, 2-paragraph summary
+- Stories numbered 1–10
+- Header shows today's date
+- Footer lists all sources consulted
+
+## Story Selection Criteria (Ranked)
+
+1. **Developer impact** — directly affects how developers work, build, or deploy
+2. **Security** — threats, breaches, or policy affecting software supply chains
+3. **AI tooling** — new models, coding assistants, agent frameworks
+4. **Industry signal** — major layoffs, acquisitions, or pivots at large tech companies
+5. **Open source / standards** — notable releases, RFCs, language changes
+6. **Policy / regulation** — laws or rulings that affect software, privacy, or the internet
+
+## References
+
+- HTML output template: `references/html-template.md`
+- Source priority guide: `references/sources.md`

--- a/daily-tech-brief/references/html-template.md
+++ b/daily-tech-brief/references/html-template.md
@@ -1,0 +1,61 @@
+# HTML Output Template
+
+Use this structure for the daily tech brief HTML output. Keep styling minimal and readable.
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Daily Tech Brief — {DATE}</title>
+  <style>
+    body { font-family: Georgia, serif; max-width: 750px; margin: 40px auto; padding: 0 20px; line-height: 1.7; color: #222; }
+    h1 { font-size: 1.5rem; border-bottom: 2px solid #222; padding-bottom: 8px; }
+    .meta { color: #666; font-size: 0.85rem; margin-bottom: 30px; }
+    h2 { font-size: 1.1rem; margin-top: 2em; margin-bottom: 4px; }
+    .source { font-size: 0.8rem; color: #888; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 6px; }
+    p { margin: 0.5em 0 1em; }
+    a { color: #1a0dab; }
+    hr { border: none; border-top: 1px solid #ddd; margin: 2em 0; }
+  </style>
+</head>
+<body>
+
+<h1>Daily Tech Brief — {DATE}</h1>
+<p class="meta">Curated for software developers &mdash; {SOURCE_LIST}</p>
+
+<hr>
+
+<!-- Repeat this block for each story -->
+<h2>{N}. {HEADLINE}</h2>
+<p class="source">{SOURCE_NAME} &mdash; <a href="{ARTICLE_URL}">Read full article</a></p>
+<p>{PARAGRAPH_1}</p>
+<p>{PARAGRAPH_2}</p>
+<hr>
+<!-- End story block -->
+
+<p class="meta">Sources consulted: {SOURCE_LINKS}</p>
+
+</body>
+</html>
+```
+
+## Variables
+
+| Variable | Description |
+|----------|-------------|
+| `{DATE}` | Full date, e.g. "March 16, 2026" |
+| `{SOURCE_LIST}` | Comma-separated plain-text source names |
+| `{N}` | Story number (1–10) |
+| `{HEADLINE}` | Article headline, kept concise |
+| `{SOURCE_NAME}` | Publication name, e.g. "Ars Technica" |
+| `{ARTICLE_URL}` | Direct link to the article |
+| `{PARAGRAPH_1}` | What happened and why it matters |
+| `{PARAGRAPH_2}` | Context, implications, or developer-relevant detail |
+| `{SOURCE_LINKS}` | Anchor tags for each source consulted |
+
+## Output File Naming
+
+Save to: `/tmp/daily-tech-brief-YYYY-MM-DD.html`
+
+Example: `/tmp/daily-tech-brief-2026-03-16.html`

--- a/daily-tech-brief/references/sources.md
+++ b/daily-tech-brief/references/sources.md
@@ -1,0 +1,81 @@
+# Source Priority Guide
+
+Reference for which sources to fetch and how to prioritize their content.
+
+## Source Discovery (Preventing Stale Coverage)
+
+**Do not rely solely on the static source list below.** Publication schedules vary — some sources may have few fresh articles on a given day. Use the following discovery approach on every run:
+
+### Step 1: Check News Aggregators First
+
+Start with aggregators that surface what's actually trending *today*, rather than always hitting the same homepages:
+
+| Aggregator | URL | Notes |
+|------------|-----|-------|
+| Hacker News front page | https://news.ycombinator.com/ | Community-ranked; reflects what developers care about right now |
+| Google News – Technology | https://news.google.com/topics/CAAqJggKIiBDQkFTRWdvSUwyMHZNRGRqTVhZU0FtVnVHZ0pWVXlBQVAB | Broad real-time index across hundreds of outlets |
+| Techmeme | https://www.techmeme.com/ | Algorithm + human editors; shows the most-linked tech stories of the day |
+
+Pull these **first**. They will point you to specific outlets and articles that are actually hot today, not just outlets you've hardcoded.
+
+### Step 2: Follow the Links
+
+From aggregator results, follow the links to the actual source articles. This means you'll naturally end up reading from whatever outlets published the most relevant stories today — which changes daily.
+
+### Step 3: Validate Freshness
+
+Before including a story, check its publication date. Only include stories published within the **last 48 hours**. If an article has no visible date, skip it.
+
+For RSS feeds (e.g., Ars Technica), use the `<pubDate>` field to filter. Discard items older than 48 hours.
+
+---
+
+## Primary Sources (Reliable Daily Coverage)
+
+These sources publish tech news every day and are worth checking directly if the aggregators miss something:
+
+| Source | URL | Format | Notes |
+|--------|-----|--------|-------|
+| Hacker News | https://news.ycombinator.com/ | HTML | Sort by points. Stories with 100+ points are strong candidates. |
+| Ars Technica | https://feeds.arstechnica.com/arstechnica/index | RSS/XML | Use RSS for clean structured data. Filter to `AI`, `Tech`, `Security`, `Science` categories. |
+| The Verge | https://www.theverge.com/tech | HTML | Tech section landing page. |
+| Engadget | https://www.engadget.com/ | HTML | Good for consumer tech, AI product news, streaming. |
+
+## Secondary Sources (Fetch When Possible)
+
+Fetch these to broaden coverage, especially if primary sources are thin:
+
+| Source | URL | Format | Notes |
+|--------|-----|--------|-------|
+| Wired | https://www.wired.com/ | HTML | Best for security, policy, and in-depth features. |
+| MIT Technology Review | https://www.technologyreview.com/ | HTML | Research, AI, energy, and emerging tech. |
+| TechCrunch | https://techcrunch.com/ | HTML | Startups, funding rounds, industry moves. |
+| The Register | https://www.theregister.com/ | HTML | Enterprise, security, UK/EU policy. |
+| 9to5Mac | https://9to5mac.com/ | HTML | Apple platform and developer news. |
+| Krebs on Security | https://krebsonsecurity.com/ | HTML | Cybersecurity and cybercrime. |
+
+---
+
+## Scoring Stories
+
+When deciding which 10 stories to include, score each candidate:
+
+- **+3** — Directly affects how developers write, test, or deploy software
+- **+3** — Major security vulnerability or supply-chain attack
+- **+2** — New AI model, coding tool, or agent framework release
+- **+2** — Significant industry event (layoffs >10%, major acquisition, IPO)
+- **+2** — Open source release or programming language update
+- **+1** — Trending on Hacker News (100+ points)
+- **+1** — Policy/regulation with direct tech impact
+- **−2** — Primarily a consumer product story with no developer angle
+- **−3** — Deals, discounts, or non-news content
+
+Pick the 10 highest-scoring stories. Break ties by favoring the story from the higher-priority source.
+
+---
+
+## Handling Paywalls and Errors
+
+- If a source returns 401/403 or requires login, skip it and note in the footer.
+- Bloomberg and Reuters frequently block scrapers — skip and substitute another source.
+- If an article page is truncated, use what's available plus the headline to write the summary.


### PR DESCRIPTION
## Daily Tech Brief Skill

Adds a new Agent Skill that fetches and summarizes the **top 10 tech news stories of the day**, curated specifically for software developers.

### What it does
- Fetches headlines in parallel from 10+ sources (Hacker News, The Verge, Ars Technica, Wired, Engadget, MIT Technology Review, TechCrunch, and more)
- Uses news aggregators (Techmeme, Google News) to discover what's actually trending *today* rather than always hitting the same homepages
- Scores and selects the 10 most developer-relevant stories across categories: security, AI/ML, open source, industry, policy
- Outputs a clean, barebones HTML page opened directly in the browser

### Files
```
daily-tech-brief/
├── SKILL.md                         # Full workflow & instructions
└── references/
    ├── html-template.md             # Minimal HTML output template
    └── sources.md                   # Source priority + freshness/discovery guide
```

### Triggers
Invoke this skill when the user asks for a _"daily tech brief"_, _"tech news"_, _"what happened in tech today"_, _"top tech stories"_, _"morning roundup"_, or similar.