### PR TITLE
feat: switch all sources to RSS, replace Wired with Stack Overflow Blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Skills are markdown prompt files that give an agent specialized behaviors. Each 
 
 | Skill | Description |
 |-------|-------------|
-| [daily-tech-brief](skills/daily-tech-brief/) | Fetches and summarizes the top 10 tech news stories of the day, curated for software developers. Outputs a clean HTML page opened in the browser. |
+| [daily-tech-brief](skills/daily-tech-brief/) | Fetches and summarizes the top 10 tech news stories of the day, curated for software developers. Outputs formatted text directly in the conversation. |
 
 ### Using Skills
 

--- a/skills/daily-tech-brief/SKILL.md
+++ b/skills/daily-tech-brief/SKILL.md
@@ -22,28 +22,28 @@ Fetch in passes — **aggregators first**, then primary outlets. This surfaces w
 
 | Source | URL | Best For |
 |--------|-----|----------|
-| Hacker News | https://news.ycombinator.com/ | Community-ranked developer picks; open source, tools, security |
-| Techmeme | https://www.techmeme.com/ | Algorithm + human editors; most-linked tech stories of the day. **Skip the "Sponsor Posts" section.** |
-| lobste.rs | https://lobste.rs/ | Developer-curated; programming languages, tools, open source |
+| Hacker News | https://news.ycombinator.com/ | Community-ranked developer picks; open source, tools, security. **Fetch as HTML** — RSS omits vote counts needed for trending filter. |
+| Techmeme | https://www.techmeme.com/feed.xml (RSS) | Algorithm + human editors; most-linked tech stories of the day. **Skip the "Sponsor Posts" section.** |
+| lobste.rs | https://lobste.rs/rss (RSS) | Developer-curated; programming languages, tools, open source |
 
 ### Pass 2 — Primary Outlets (Deep Developer Coverage)
 
 | Source | URL | Best For |
 |--------|-----|----------|
 | Ars Technica | https://feeds.arstechnica.com/arstechnica/technology-lab (RSS) | Deep technical coverage — AI, security, software, science |
-| The Register | https://www.theregister.com/ | Enterprise tech, security, infrastructure, UK/EU policy |
+| The Register | https://www.theregister.com/headlines.atom (Atom) | Enterprise tech, security, infrastructure, UK/EU policy |
 | The New Stack | https://thenewstack.io/feed/ (RSS) | DevOps, Kubernetes, cloud-native, microservices |
-| GitHub Blog | https://github.blog/ | Platform updates, open source releases, security advisories |
+| GitHub Blog | https://github.blog/feed/ (RSS) | Platform updates, open source releases, security advisories |
 
 ### Pass 3 — Secondary Sources (Fetch When Needed for Breadth)
 
 | Source | URL | Best For |
 |--------|-----|----------|
-| Krebs on Security | https://krebsonsecurity.com/ | Cybersecurity and cybercrime |
-| InfoQ | https://www.infoq.com/ | Software architecture, AI tooling, enterprise dev |
-| Wired | https://www.wired.com/ | Security policy, in-depth features |
-| TechCrunch | https://techcrunch.com/ | Startups, funding, industry moves |
-| MIT Technology Review | https://www.technologyreview.com/ | AI/ML research, emerging tech (often paywalled — use headlines only) |
+| Krebs on Security | https://krebsonsecurity.com/feed/ (RSS) | Cybersecurity and cybercrime |
+| InfoQ | https://feed.infoq.com/ (RSS) | Software architecture, AI tooling, enterprise dev |
+| Stack Overflow Blog | https://stackoverflow.blog/feed/ (RSS) | Developer community insights, AI/ML tools, engineering practices |
+| TechCrunch | https://techcrunch.com/feed/ (RSS) | Startups, funding, industry moves |
+| MIT Technology Review | https://www.technologyreview.com/feed/ (RSS) | AI/ML research, emerging tech (often paywalled — use headlines only) |
 
 ## Step-by-Step Workflow
 
@@ -61,12 +61,12 @@ From these results, collect headlines and links generating the most attention �
 
 ### Step 2: Broaden with Primary Outlets
 
-Fetch **primary outlets in parallel** to catch important developer stories aggregators may have missed. Use RSS where available for clean structured data:
+Fetch **primary outlets in parallel** to catch important developer stories aggregators may have missed. All primary outlets now have RSS/Atom feeds for clean structured data:
 
 - Ars Technica Technology Lab RSS: `https://feeds.arstechnica.com/arstechnica/technology-lab`
-- The Register: `https://www.theregister.com/`
+- The Register Atom: `https://www.theregister.com/headlines.atom`
 - The New Stack RSS: `https://thenewstack.io/feed/`
-- GitHub Blog: `https://github.blog/`
+- GitHub Blog RSS: `https://github.blog/feed/`
 
 ### Step 3: Fetch Article Detail for Top Candidates
 

--- a/skills/daily-tech-brief/references/sources.md
+++ b/skills/daily-tech-brief/references/sources.md
@@ -6,11 +6,11 @@ Reference for which sources to fetch and how to prioritize their content.
 
 Start with aggregators that surface what's actually trending *today*. These are the most important sources — they tell you what the developer community is talking about right now without guessing which outlets published something interesting.
 
-| Aggregator | URL | Notes |
-|------------|-----|-------|
-| Hacker News | https://news.ycombinator.com/ | Community-ranked; best signal for what developers care about right now |
-| Techmeme | https://www.techmeme.com/ | Algorithm + human editors; shows the most-linked tech stories of the day. **Skip the "Sponsor Posts" section.** |
-| lobste.rs | https://lobste.rs/ | Developer-curated community; heavier focus on programming, tools, and open source than HN |
+| Aggregator | URL | Format | Notes |
+|------------|-----|--------|-------|
+| Hacker News | https://news.ycombinator.com/ | HTML | Community-ranked; best signal for what developers care about right now. **Keep as HTML** — the RSS feed omits vote counts needed for the "100+ points" trending filter. |
+| Techmeme | https://www.techmeme.com/feed.xml | RSS/XML | Algorithm + human editors; shows the most-linked tech stories of the day. **Skip the "Sponsor Posts" section.** |
+| lobste.rs | https://lobste.rs/rss | RSS/XML | Developer-curated community; heavier focus on programming, tools, and open source than HN. RSS includes categories for easy filtering. |
 
 Pull these **before** hitting individual outlets. They will point you to specific articles that are actually hot today.
 
@@ -33,19 +33,19 @@ Fetch these **after aggregators** to catch important developer stories the aggre
 | Source | URL | Format | Notes |
 |--------|-----|--------|-------|
 | Ars Technica | https://feeds.arstechnica.com/arstechnica/technology-lab | RSS/XML | Technology Lab feed — AI, security, software, science. Avoids Cars/Gaming categories from the general feed. |
-| The Register | https://www.theregister.com/ | HTML | Enterprise tech, security, infrastructure, UK/EU policy. |
+| The Register | https://www.theregister.com/headlines.atom | Atom/XML | Enterprise tech, security, infrastructure, UK/EU policy. |
 | The New Stack | https://thenewstack.io/feed/ | RSS/XML | DevOps, Kubernetes, cloud-native, microservices. Use RSS — homepage is JS-heavy. |
-| GitHub Blog | https://github.blog/ | HTML | Platform updates, open source releases, security advisories. Low-volume but highly targeted. |
+| GitHub Blog | https://github.blog/feed/ | RSS/XML | Platform updates, open source releases, security advisories. Low-volume but highly targeted. |
 
 ## Secondary Sources (Fetch When Primary Sources Are Thin)
 
 | Source | URL | Format | Notes |
 |--------|-----|--------|-------|
-| Krebs on Security | https://krebsonsecurity.com/ | HTML | Cybersecurity and cybercrime — high signal for supply chain and threat news. |
-| InfoQ | https://www.infoq.com/ | HTML | Software architecture, AI/ML tooling, enterprise development practices. |
-| Wired | https://www.wired.com/ | HTML | Security policy and in-depth features with a tech/society angle. |
-| TechCrunch | https://techcrunch.com/ | HTML | Startups, funding rounds, and industry moves. |
-| MIT Technology Review | https://www.technologyreview.com/ | HTML | AI/ML research and emerging tech. Often paywalled — use headlines only if article body is blocked. |
+| Krebs on Security | https://krebsonsecurity.com/feed/ | RSS/XML | Cybersecurity and cybercrime — high signal for supply chain and threat news. Full article content in feed. |
+| InfoQ | https://feed.infoq.com/ | RSS/XML | Software architecture, AI/ML tooling, enterprise development practices. |
+| Stack Overflow Blog | https://stackoverflow.blog/feed/ | RSS/XML | Developer community insights, AI/ML tools, engineering practices. Developer-focused throughout — no consumer noise. |
+| TechCrunch | https://techcrunch.com/feed/ | RSS/XML | Startups, funding rounds, and industry moves. |
+| MIT Technology Review | https://www.technologyreview.com/feed/ | RSS/XML | AI/ML research and emerging tech. Often paywalled — use headlines only if article body is blocked. |
 
 ---
 


### PR DESCRIPTION
## Summary

Switches all daily-tech-brief sources from HTML scraping to RSS/Atom feeds for cleaner, structured data. Also replaces Wired with Stack Overflow Blog after a quality audit, and fixes a stale README description.

## Changes

### `README.md`
- Fix stale description: skill outputs formatted text in the conversation, not an HTML page in the browser.

### `SKILL.md` + `references/sources.md`
- **lobste.rs** → RSS `https://lobste.rs/rss` (includes categories for filtering)
- **Techmeme** → RSS `https://www.techmeme.com/feed.xml` (structured; filter sponsor entries)
- **The Register** → Atom `https://www.theregister.com/headlines.atom`
- **GitHub Blog** → RSS `https://github.blog/feed/`
- **Krebs on Security** → RSS `https://krebsonsecurity.com/feed/` (full article content)
- **InfoQ** → RSS `https://feed.infoq.com/`
- **TechCrunch** → RSS `https://techcrunch.com/feed/`
- **MIT Technology Review** → RSS `https://www.technologyreview.com/feed/`
- **Hacker News** — stays HTML (RSS omits vote counts needed for trending filter)
- **Ars Technica** — already on RSS ✅
- **The New Stack** — already on RSS ✅

### Source quality swap
- ❌ **Removed Wired** — RSS feed top items were a bicycle review, hair growth device sale, and pool robot review. Not developer-focused.
- ✅ **Added Stack Overflow Blog** (`https://stackoverflow.blog/feed/`) — developer community insights, engineering practices, AI/ML tooling. Verified RSS top items: open-source robotics OS, enterprise AI context — both developer-focused.

## Testing
All RSS/Atom URLs were fetched and verified for content quality before inclusion.