### PR TITLE
fix: address all repo audit issues

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Chandler Klein
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agent
 
-A collection of resources for AI agents — including skills, prompt templates, and reference materials.
+A collection of skills and resources for AI agents.
 
 ## Contents
 

--- a/skills/daily-tech-brief/SKILL.md
+++ b/skills/daily-tech-brief/SKILL.md
@@ -23,27 +23,27 @@ Fetch in passes — **aggregators first**, then primary outlets. This surfaces w
 | Source | URL | Best For |
 |--------|-----|----------|
 | Hacker News | https://news.ycombinator.com/ | Community-ranked developer picks; open source, tools, security. **Fetch as HTML** — RSS omits vote counts needed for trending filter. |
-| Techmeme | https://www.techmeme.com/feed.xml (RSS) | Algorithm + human editors; most-linked tech stories of the day. **Skip the "Sponsor Posts" section.** |
-| lobste.rs | https://lobste.rs/rss (RSS) | Developer-curated; programming languages, tools, open source |
+| Techmeme | https://www.techmeme.com/feed.xml | Algorithm + human editors; most-linked tech stories of the day. **Filter out any item that appears to be a paid placement** (sponsor entries appear inline in the RSS feed). |
+| lobste.rs | https://lobste.rs/rss | Developer-curated; programming languages, tools, open source |
 
 ### Pass 2 — Primary Outlets (Deep Developer Coverage)
 
 | Source | URL | Best For |
 |--------|-----|----------|
-| Ars Technica | https://feeds.arstechnica.com/arstechnica/technology-lab (RSS) | Deep technical coverage — AI, security, software, science |
-| The Register | https://www.theregister.com/headlines.atom (Atom) | Enterprise tech, security, infrastructure, UK/EU policy |
-| The New Stack | https://thenewstack.io/feed/ (RSS) | DevOps, Kubernetes, cloud-native, microservices |
-| GitHub Blog | https://github.blog/feed/ (RSS) | Platform updates, open source releases, security advisories |
+| Ars Technica | https://feeds.arstechnica.com/arstechnica/technology-lab | Deep technical coverage — AI, security, software, science |
+| The Register | https://www.theregister.com/headlines.atom | Enterprise tech, security, infrastructure, UK/EU policy |
+| The New Stack | https://thenewstack.io/feed/ | DevOps, Kubernetes, cloud-native, microservices |
+| GitHub Blog | https://github.blog/feed/ | Platform updates, open source releases, security advisories |
 
 ### Pass 3 — Secondary Sources (Fetch When Needed for Breadth)
 
 | Source | URL | Best For |
 |--------|-----|----------|
-| Krebs on Security | https://krebsonsecurity.com/feed/ (RSS) | Cybersecurity and cybercrime |
-| InfoQ | https://feed.infoq.com/ (RSS) | Software architecture, AI tooling, enterprise dev |
-| Stack Overflow Blog | https://stackoverflow.blog/feed/ (RSS) | Developer community insights, AI/ML tools, engineering practices |
-| TechCrunch | https://techcrunch.com/feed/ (RSS) | Startups, funding, industry moves |
-| MIT Technology Review | https://www.technologyreview.com/feed/ (RSS) | AI/ML research, emerging tech (often paywalled — use headlines only) |
+| Krebs on Security | https://krebsonsecurity.com/feed/ | Cybersecurity and cybercrime |
+| InfoQ | https://feed.infoq.com/ | Software architecture, AI tooling, enterprise dev |
+| Stack Overflow Blog | https://stackoverflow.blog/feed/ | Developer community insights, AI/ML tools, engineering practices |
+| TechCrunch | https://techcrunch.com/feed/ | Startups, funding, industry moves |
+| MIT Technology Review | https://www.technologyreview.com/feed/ | AI/ML research, emerging tech (often paywalled — use headlines only) |
 
 ## Step-by-Step Workflow
 
@@ -54,10 +54,10 @@ Use the `web_fetch` tool to load **all three aggregators simultaneously**. These
 | Aggregator | URL |
 |------------|-----|
 | Hacker News | https://news.ycombinator.com/ |
-| Techmeme | https://www.techmeme.com/ |
-| lobste.rs | https://lobste.rs/ |
+| Techmeme | https://www.techmeme.com/feed.xml |
+| lobste.rs | https://lobste.rs/rss |
 
-From these results, collect headlines and links generating the most attention — this is your initial candidate pool. On Techmeme, skip the "Sponsor Posts" section at the top.
+From these results, collect headlines and links generating the most attention — this is your initial candidate pool. For Techmeme, filter out any items that appear to be paid placements (sponsor entries appear as regular items in the RSS feed — skip anything that reads as an advertisement rather than editorial coverage).
 
 ### Step 2: Broaden with Primary Outlets
 

--- a/skills/daily-tech-brief/references/sources.md
+++ b/skills/daily-tech-brief/references/sources.md
@@ -9,7 +9,7 @@ Start with aggregators that surface what's actually trending *today*. These are 
 | Aggregator | URL | Format | Notes |
 |------------|-----|--------|-------|
 | Hacker News | https://news.ycombinator.com/ | HTML | Community-ranked; best signal for what developers care about right now. **Keep as HTML** — the RSS feed omits vote counts needed for the "100+ points" trending filter. |
-| Techmeme | https://www.techmeme.com/feed.xml | RSS/XML | Algorithm + human editors; shows the most-linked tech stories of the day. **Skip the "Sponsor Posts" section.** |
+| Techmeme | https://www.techmeme.com/feed.xml | RSS/XML | Algorithm + human editors; shows the most-linked tech stories of the day. **Sponsor entries appear as regular items in the RSS feed** — skip any item that reads as an advertisement rather than editorial coverage. |
 | lobste.rs | https://lobste.rs/rss | RSS/XML | Developer-curated community; heavier focus on programming, tools, and open source than HN. RSS includes categories for easy filtering. |
 
 Pull these **before** hitting individual outlets. They will point you to specific articles that are actually hot today.
@@ -22,7 +22,7 @@ From aggregator results, follow links to the actual source articles. This means 
 
 Before including a story, check its publication date. Only include stories published within the **last 48 hours**. If an article has no visible date, skip it.
 
-For RSS feeds, use the `<pubDate>` field to filter. Discard items older than 48 hours.
+For RSS feeds, use the `<pubDate>` field to filter. For Atom feeds (e.g., The Register's `.atom` feed), use `<updated>` or `<published>` instead — Atom does not use `<pubDate>`. Discard items older than 48 hours regardless of format.
 
 ---
 
@@ -63,7 +63,7 @@ When deciding which 10 stories to include, score each candidate:
 - **−2** — Primarily a consumer product story with no developer angle
 - **−3** — Deals, discounts, or non-news content
 
-Pick the 10 highest-scoring stories. Break ties by favoring the story from the higher-priority source.
+Pick the 10 highest-scoring stories. Break ties by favoring the story from the higher-priority source. Scores are additive per story — a single story can accumulate points across multiple criteria.
 
 ---
 


### PR DESCRIPTION
## What

Fixes all issues identified in the repository audit.

## Changes

### `SKILL.md`
- **Fix #1 (High):** Step 1 workflow table had stale HTML URLs for Techmeme (`techmeme.com/`) and lobste.rs (`lobste.rs/`) left over from before the RSS migration in PR #7. Updated to match the Pass 1 source table: `feed.xml` and `/rss`.
- **Fix #3:** Techmeme sponsor note said "skip the Sponsor Posts section at the top" — language for the HTML page layout. In the RSS feed, sponsor entries appear inline as regular items. Updated note describes how to identify them in a feed context.
- **Fix #4:** Removed `(RSS)` and `(Atom)` format annotations embedded inside URL column values. These are not valid URL suffixes and could trip up an agent using the value directly as a fetch URL. URLs are self-descriptive by extension.

### `references/sources.md`
- **Fix #2 (Medium):** Freshness filter only mentioned `<pubDate>`, which is RSS-specific. The Register's feed is Atom, which uses `<updated>`/`<published>`. Updated to document both.
- **Fix #3:** Same Techmeme sponsor note fix.
- **Fix #9:** Added note that scoring criteria are additive per story.

### `README.md`
- **Fix #8:** Simplified intro — removed mention of "prompt templates, and reference materials" which don't exist in the repo yet.

### `LICENSE`
- **Fix #7:** Added MIT license. Repo was public with no license, making reuse legally ambiguous.
