### PR TITLE
fix: align Pass 3 label and primary sources intro wording

### DIFF
--- a/skills/daily-tech-brief/SKILL.md
+++ b/skills/daily-tech-brief/SKILL.md
@@ -35,7 +35,7 @@ Fetch in passes — **aggregators first**, then primary outlets. This surfaces w
 | The New Stack | https://thenewstack.io/feed/ | DevOps, Kubernetes, cloud-native, microservices |
 | GitHub Blog | https://github.blog/feed/ | Platform updates, open source releases, security advisories |
 
-### Pass 3 — Secondary Sources (Fetch When Needed for Breadth)
+### Pass 3 — Secondary Sources (Fetch When Primary Sources Are Thin)
 
 | Source | URL | Best For |
 |--------|-----|----------|

--- a/skills/daily-tech-brief/references/sources.md
+++ b/skills/daily-tech-brief/references/sources.md
@@ -28,7 +28,7 @@ For RSS feeds, use the `<pubDate>` field to filter. For Atom feeds (e.g., The Re
 
 ## Primary Sources (Deep Developer Coverage)
 
-Fetch these **after aggregators** to catch important developer stories the aggregators may have missed. Use RSS where available — these sites are often JavaScript-heavy and RSS gives cleaner, more complete content:
+Fetch these **after aggregators** to catch important developer stories the aggregators may have missed. All primary sources have RSS/Atom feeds — use them for clean, structured data:
 
 | Source | URL | Format | Notes |
 |--------|-----|--------|-------|


### PR DESCRIPTION
Two minor wording inconsistencies caught in follow-up audit:

1. Pass 3 label mismatch: SKILL.md called it "Fetch When Needed for Breadth"; sources.md called the same section "Fetch When Primary Sources Are Thin". Standardized both to "Fetch When Primary Sources Are Thin".

2. Stale primary sources intro: sources.md said "Use RSS where available" which was written before all primary sources had feeds. All primary outlets now have RSS/Atom. Updated to reflect that.
